### PR TITLE
Change to source directory before iterating

### DIFF
--- a/Sort Scanned Files
+++ b/Sort Scanned Files
@@ -1,7 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
-set source="C:\Users\Artifex Wines\Dropbox\Production Files\Admin\SCANS EN ROUTE"
-set base_destination="C:\Users\Artifex Wines\Dropbox"
+set "source=C:\Users\Artifex Wines\Dropbox\Production Files\Admin\SCANS EN ROUTE"
+set "base_destination=C:\Users\Artifex Wines\Dropbox"
 
 rem Define client code to client name mappings
 set "AQ=Aquilini"
@@ -17,7 +17,9 @@ set "R=Rivaura"
 set "S=SMAK"
 set "V=Vital"
 
-for %%f in ("%source%\*") do (
+cd "%source%"
+
+for %%f in (*.*) do (
     set "filename=%%~nxf"
     set "extension=%%~xf"
 


### PR DESCRIPTION
This updates the start of the command to change to the source directory before looking for files, so that the for loop doesn't use the "source" variable. This strategy seemed to work on my machine.

Also updates the source and base_destination declarations so that the variables themselves don't have quotes inside them, otherwise they seem to get double-quoted.